### PR TITLE
slit/term+follow: fix bug where initial window height is 0 +  change "follow" flag meaning

### DIFF
--- a/term.go
+++ b/term.go
@@ -2,20 +2,21 @@ package slit
 
 import (
 	"bufio"
-	"code.cloudfoundry.org/bytefmt"
 	"context"
 	"fmt"
-	"github.com/nsf/termbox-go"
-	"github.com/tigrawap/slit/ansi"
-	"github.com/tigrawap/slit/filters"
-	"github.com/tigrawap/slit/logging"
-	"github.com/tigrawap/slit/utils"
 	"io"
 	"os"
 	"runtime"
 	"strconv"
 	"sync"
 	"time"
+
+	"code.cloudfoundry.org/bytefmt"
+	"github.com/nsf/termbox-go"
+	"github.com/tigrawap/slit/ansi"
+	"github.com/tigrawap/slit/filters"
+	"github.com/tigrawap/slit/logging"
+	"github.com/tigrawap/slit/utils"
 )
 
 type viewer struct {
@@ -454,7 +455,9 @@ func (v *viewer) processKey(ev termbox.Event) (a action) {
 func (v *viewer) resize(width, height int) {
 	v.sizeLock.Lock()
 	v.width, v.height = width, height
-	v.height-- // Saving one Line for infobar
+	if v.height > 0 {
+		v.height-- // Saving one Line for infobar
+	}
 	v.sizeLock.Unlock()
 	v.info.resize(v.width, v.height)
 	v.buffer.window = v.height

--- a/viewbuffer.go
+++ b/viewbuffer.go
@@ -2,10 +2,11 @@ package slit
 
 import (
 	"context"
-	"github.com/tigrawap/slit/filters"
-	"github.com/tigrawap/slit/logging"
 	"io"
 	"sync"
+
+	"github.com/tigrawap/slit/filters"
+	"github.com/tigrawap/slit/logging"
 )
 
 type viewBuffer struct {
@@ -245,6 +246,7 @@ func (b *viewBuffer) shiftToEnd() {
 		return
 	}
 	b.pos = len(b.buffer) - b.window
+	b.originalPos = b.currentLine().Pos
 }
 func (b *viewBuffer) toggleCurrentHighlight() {
 	b.buffer[b.pos].Highlighted = !b.buffer[b.pos].Highlighted


### PR DESCRIPTION
Always add new log lines from stdin to terminal view (change goroutine to periodically poll and redraw).
adapt --follow to move terminal to new last log line. It will not move terminal if user navigated to a different location (as it used to).